### PR TITLE
Fix model point sampling in data_loader

### DIFF
--- a/core/gdrn_modeling/data_loader.py
+++ b/core/gdrn_modeling/data_loader.py
@@ -234,8 +234,7 @@ class GDRN_DatasetFromList(Base_DatasetFromList):
 
         num = min(num, cfg.MODEL.CDPN.PNP_NET.NUM_PM_POINTS)
         for i in range(len(cur_model_points)):
-            keep_idx = np.arange(num)
-            np.random.shuffle(keep_idx)  # random sampling
+            keep_idx = np.random.choice(len(cur_model_points[i]), num, replace=False)
             cur_model_points[i] = cur_model_points[i][keep_idx, :]
 
         self.model_points[dataset_name] = cur_model_points


### PR DESCRIPTION
This pull request addresses a bug in the model point selection process, where the original implementation always selected the first NUM_PM_POINTS from the model, despite shuffling. The shuffling only affected the first indices, leading to a biased selection of model points. The updated code ensures that a random and unbiased subset of points is selected.